### PR TITLE
issue #19

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -167,7 +167,7 @@ function parseDate(str,strict) {
     if (!found_year) {
       result = YEAR.exec(token);
       if (result) {
-        var year = result[0];
+        var year = +result[0];
         /* From S5.1.1:
          * 3.  If the year-value is greater than or equal to 70 and less
          * than or equal to 99, increment the year-value by 1900.


### PR DESCRIPTION
Fixed 2-digit year workaround.
One plus-sign added converts a 2-digit year-string to an integer before the year-value is incremented.