### PR TITLE
Implement loose mode for cookie jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,15 +237,15 @@ if (cookie.validate() === true) {
 
 Exported via `tough.CookieJar`.
 
-### `CookieJar([store],[rejectPublicSuffixes])`
+### `CookieJar([store],[options])`
 
 Simply use `new CookieJar()`.  If you'd like to use a custom store, pass that to the constructor otherwise a `MemoryCookieStore` will be created and used.
 
-### Properties
+The `options` object can be omitted and can have the following properties:
 
-CookieJar object properties:
-
-  * _rejectPublicSuffixes_ - boolean - reject cookies with domains like "com" and "co.uk" (default: `true`)
+  * _rejectPublicSuffixes_ - boolean - default `true` - reject cookies with domains like "com" and "co.uk"
+  * _looseMode_ - boolean - default `false` - accept malformed cookies like `bar` and `=bar`, which have an implied empty name.
+    This is not in the standard, but is used sometimes on the web and is accepted by (most) browsers.
 
 Since eventually this module would like to support database/remote/etc. CookieJars, continuation passing style is used for CookieJar methods.
 

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -878,9 +878,17 @@ Cookie.prototype.canonicalizedDomain = function canonicalizedDomain() {
   return canonicalDomain(this.domain);
 };
 
-function CookieJar(store, rejectPublicSuffixes) {
-  if (rejectPublicSuffixes != null) {
-    this.rejectPublicSuffixes = rejectPublicSuffixes;
+function CookieJar(store, options) {
+  if (typeof options === "boolean") {
+    options = {rejectPublicSuffixes: options};
+  } else if (options == null) {
+    options = {};
+  }
+  if (options.rejectPublicSuffixes != null) {
+    this.rejectPublicSuffixes = options.rejectPublicSuffixes;
+  }
+  if (options.looseMode != null) {
+    this.enableLooseMode = options.looseMode;
   }
 
   if (!store) {
@@ -890,6 +898,7 @@ function CookieJar(store, rejectPublicSuffixes) {
 }
 CookieJar.prototype.store = null;
 CookieJar.prototype.rejectPublicSuffixes = true;
+CookieJar.prototype.enableLooseMode = false;
 var CAN_BE_SYNC = [];
 
 CAN_BE_SYNC.push('setCookie');
@@ -902,10 +911,14 @@ CookieJar.prototype.setCookie = function(cookie, url, options, cb) {
   }
 
   var host = canonicalDomain(context.hostname);
+  var loose = this.enableLooseMode;
+  if (options.loose != null) {
+    loose = options.loose;
+  }
 
   // S5.3 step 1
   if (!(cookie instanceof Cookie)) {
-    cookie = Cookie.parse(cookie, { loose: options.loose });
+    cookie = Cookie.parse(cookie, { loose: loose });
   }
   if (!cookie) {
     err = new Error("Cookie failed to parse");

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -465,4 +465,19 @@ vows
       }
     }
   })
+  .addBatch({
+    "Loose Mode": {
+      topic: function () {
+        var cj = new CookieJar(null, {looseMode: true});
+        cj.setCookieSync("FooBar", 'http://www.foonet.net', {});
+        return cj;
+      },
+      "parses loose cookies": function (cj) {
+        var cookies = cj.getCookiesSync('http://www.foonet.net');
+        assert.strictEqual(cookies.length, 1);
+        assert.strictEqual(cookies[0].key, '');
+        assert.strictEqual(cookies[0].value, 'FooBar');
+      }
+    }
+  })
   .export(module);


### PR DESCRIPTION
Forgot that this might be needed too, especially if tough-cookie is used in conjunction with `request`, which doesn't set loose by default.

I was thinking about doing an options object as a param instead, but I don't think that the already existing option can be replaced in a backwards-compatible way, so we could only add an options object in addition. Not sure about what to do here.