### PR TITLE
Simplification of (LOOSE_)COOKIE_PAIR regular expressions.

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -58,11 +58,11 @@ var CONTROL_CHARS = /[\x00-\x1F]/;
 // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L60)
 // '=' and ';' are attribute/values separators
 // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L64)
-var COOKIE_PAIR = /^(([^=;]+))\s*=\s*(("?)[^\n\r\0]*\3)/
+var COOKIE_PAIR = /^(([^=;]+))\s*=\s*([^\n\r\0]*)/;
 
 // Used to parse non-RFC-compliant cookies like '=abc' when given the `loose`
 // option in Cookie.parse:
-var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?(("?)[^\n\r\0]*\3)/;
+var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?([^\n\r\0]*)/;
 
 // RFC6265 S4.1.1 defines path value as 'any CHAR except CTLs or ";"'
 // Note ';' is \x3B


### PR DESCRIPTION
This PR is a resolution of  #63.

At first I thought that I will update the regular expressions such that the value contains either no quotes or exactly two (one at the beginning and one at the end), i.e., COOKIE_PAIR would be something like  `/^(([^=;]+))\s*=\s*(("?)[^"\n\r\0]*\4)/` but then I realized that you have several tests that go against this. Note that these tests violate [RFC6265](https://tools.ietf.org/html/rfc6265#section-4.1.1). This is just heads up, I am leaving up to you whether this is something that you want.

So, eventually I've just simplified the regular expression by removing the misleading (incorrectly implemented) parts that were responsible for the check for the quotes. There are no tests in this PR because the behaviour is the same after this change - it is just a clean-up of confusing parts of the reg-exps.