### PR TITLE
S8.5 Ignore ports in cookie domains

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -432,7 +432,8 @@ function parse(str, options) {
       if (av_value) {
         // S5.2.3 "Let cookie-domain be the attribute-value without the leading %x2E
         // (".") character."
-        var domain = av_value.trim().replace(/^\./, '');
+        // S8.5 Ports should be ignored
+        var domain = av_value.trim().replace(/^\./, '').replace(/:\d{1,5}/, '');
         if (domain) {
           // "Convert the cookie-domain to lower case."
           c.domain = domain.toLowerCase();

--- a/test/ietf_data/parser.json
+++ b/test/ietf_data/parser.json
@@ -1005,7 +1005,9 @@
       "foo=bar; domain=home.example.org:8888"
     ],
     "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0027",
-    "sent": []
+    "sent": [
+      { "name": "foo", "value": "bar" }
+    ]
   },
   {
     "test": "DOMAIN0028",

--- a/test/parsing_test.js
+++ b/test/parsing_test.js
@@ -130,6 +130,11 @@ vows
       assert.ok(c);
       assert.equal(c.domain, 'example.com');
     },
+    "port in domain": function() {
+      var c = Cookie.parse("a=b; domain=example.com:80");
+      assert.ok(c);
+      assert.equal(c.domain, 'example.com');
+    },
     "trailing dot in domain": {
       topic: function() {
         return Cookie.parse("a=b; Domain=example.com.", true) || null;


### PR DESCRIPTION
I was using the request module for my test suite to hit a few different services running on the same host, but under different ports. According to the spec (8.5), ports should be entirely ignored, but tough-cookie includes them.
This PR attempts to fix that and adds a test case.
Unfortunately, it also breaks the DOMAIN0027 test, and I don't really understand why. Any feedback is most welcome!