### PR TITLE
Restore backwards compatibility to node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
 node_js:
 - stable
-- "--lts"
+- "6.0"
+- "5.12"
+- "5.0"
 - "4.4"
 - "4.0"
+- "0.12"
+- "0.10"
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 [RFC6265](https://tools.ietf.org/html/rfc6265) Cookies and CookieJar for Node.js
 
-[![Build Status](https://travis-ci.org/SalesforceEng/tough-cookie.png?branch=master)](https://travis-ci.org/SalesforceEng/tough-cookie)
+[![npm package](https://nodei.co/npm/tough-cookie.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/tough-cookie/)
 
-[![NPM Stats](https://nodei.co/npm/tough-cookie.png?downloads=true&stars=true)](https://npmjs.org/package/tough-cookie)
-![NPM Downloads](https://nodei.co/npm-dl/tough-cookie.png?months=9)
+[![Build Status](https://travis-ci.org/SalesforceEng/tough-cookie.png?branch=master)](https://travis-ci.org/SalesforceEng/tough-cookie)
 
 # Synopsis
 
@@ -29,6 +28,10 @@ It's _so_ easy!
 `npm install tough-cookie`
 
 Why the name?  NPM modules `cookie`, `cookies` and `cookiejar` were already taken.
+
+## Version Support
+
+Support for versions of node.js will follow that of the [request](https://www.npmjs.com/package/request) module.
 
 # API
 

--- a/package.json
+++ b/package.json
@@ -61,10 +61,11 @@
     "test": "vows test/*_test.js"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=0.8"
   },
   "devDependencies": {
     "async": "^1.4.2",
+    "string.prototype.repeat": "^0.2.0",
     "vows": "^0.8.1"
   }
 }

--- a/test/parsing_test.js
+++ b/test/parsing_test.js
@@ -30,6 +30,7 @@
  */
 
 'use strict';
+require('string.prototype.repeat'); // polyfill
 var vows = require('vows');
 var assert = require('assert');
 var tough = require('../lib/cookie');


### PR DESCRIPTION
Restore backwards compatibility to node 0.8 (since that's what `request` supports).